### PR TITLE
Support custom SLURM jobs

### DIFF
--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -77,10 +77,10 @@ function HasBOM {
     )
     $file=Get-Item $filename
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
-    Write-Host $bytes
-    $bytes[0] -eq 0xef
-    $bytes[1] -eq 0xbb
-    $bytes[2] -eq 0xbf
+    Announce $bytes
+    Announce $bytes[0] -eq 0xef
+    Announce $bytes[1] -eq 0xbb
+    Announce $bytes[2] -eq 0xbf
     if( $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf )
     {
         return $true

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -77,8 +77,11 @@ function HasBOM {
     )
     $file=Get-Item $filename
     Announce "here"
-    Announce $file.FullName
-    $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        [byte[]]$bytes = Get-Content -AsByteStream -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    } else {
+        [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    }
     # [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"
     Announce $bytes

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -190,9 +190,9 @@ if (-not (Test-Path -Path $sshkey)) {
    }
    SanitizeKeys -filename $sshkey
    SanitizeKeys -filename "$sshkey.pub"
-   # if ((HasBOM -filename $sshkey) -or (HasBOM -filename "$sshkey.pub")) {
-   #    throw "Generated keys contain UTF-8 marks or BOMs"
-   # }
+   if ((HasBOM -filename $sshkey) -or (HasBOM -filename "$sshkey.pub")) {
+      throw "Generated keys contain UTF-8 marks or BOMs"
+   }
    if ($PSBoundParameters.Count -eq 0) {
       $cleankey = ([Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes("$sshkey.pub")) -replace '^\uFEFF', '' -replace '[\uFEFF\r\n]', '')
       ssh $uname@$headnode "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo '$cleankey' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -186,9 +186,9 @@ if (-not (Test-Path -Path $sshkey)) {
    }
    SanitizeKeys -filename $sshkey
    SanitizeKeys -filename "$sshkey.pub"
-   if ((HasBOM -filename $sshkey) -or (HasBOM -filename "$sshkey.pub")) {
-      throw "Generated keys contain UTF-8 marks or BOMs"
-   }
+   # if ((HasBOM -filename $sshkey) -or (HasBOM -filename "$sshkey.pub")) {
+   #    throw "Generated keys contain UTF-8 marks or BOMs"
+   # }
    if ($PSBoundParameters.Count -eq 0) {
       $cleankey = ([Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes("$sshkey.pub")) -replace '^\uFEFF', '' -replace '[\uFEFF\r\n]', '')
       ssh $uname@$headnode "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo '$cleankey' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -77,6 +77,10 @@ function HasBOM {
     )
     $file=Get-Item $filename
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    Write-Host $bytes
+    $bytes[0] -eq 0xef
+    $bytes[1] -eq 0xbb
+    $bytes[2] -eq 0xbf
     if( $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf )
     {
         return $true

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -78,9 +78,8 @@ function HasBOM {
     $file=Get-Item $filename
     Announce "here"
     Announce $file.FullName
-    $ff = Get-Content -Encoding Byte -Path $file.FullName
-    Announce $ff
-    [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    [byte[]]$bytes = [System.IO.File]::ReadAllBytes($path)
+    # [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"
     Announce $bytes
     Announce $bytes[0] -eq 0xef

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -78,7 +78,7 @@ function HasBOM {
     $file=Get-Item $filename
     Announce "here"
     Announce $file.FullName
-    [byte[]]$bytes = [System.IO.File]::ReadAllBytes($path)
+    $bytes = [System.IO.File]::ReadAllBytes($path)
     # [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"
     Announce $bytes

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -78,6 +78,7 @@ function HasBOM {
     $file=Get-Item $filename
     Announce "here"
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    Announce "here2"
     Announce $bytes
     Announce $bytes[0] -eq 0xef
     Announce $bytes[1] -eq 0xbb

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -76,18 +76,11 @@ function HasBOM {
         [string]$filename
     )
     $file=Get-Item $filename
-    Announce "here"
     if ($PSVersionTable.PSVersion.Major -ge 6) {
         [byte[]]$bytes = Get-Content -AsByteStream -ReadCount 3 -TotalCount 3 -Path $file.FullName
     } else {
         [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     }
-    # [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
-    Announce "here2"
-    Announce $bytes
-    Announce $bytes[0] -eq 0xef
-    Announce $bytes[1] -eq 0xbb
-    Announce $bytes[2] -eq 0xbf
     if( $bytes[0] -eq 0xef -and $bytes[1] -eq 0xbb -and $bytes[2] -eq 0xbf )
     {
         return $true

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -76,6 +76,7 @@ function HasBOM {
         [string]$filename
     )
     $file=Get-Item $filename
+    Announce "here"
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce $bytes
     Announce $bytes[0] -eq 0xef

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -78,6 +78,8 @@ function HasBOM {
     $file=Get-Item $filename
     Announce "here"
     Announce $file.FullName
+    $ff = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    Announce $ff
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"
     Announce $bytes

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -78,7 +78,7 @@ function HasBOM {
     $file=Get-Item $filename
     Announce "here"
     Announce $file.FullName
-    $bytes = [System.IO.File]::ReadAllBytes($path)
+    $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
     # [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"
     Announce $bytes

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -77,6 +77,7 @@ function HasBOM {
     )
     $file=Get-Item $filename
     Announce "here"
+    Announce $file.FullName
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"
     Announce $bytes

--- a/client/setup.ps1
+++ b/client/setup.ps1
@@ -78,7 +78,7 @@ function HasBOM {
     $file=Get-Item $filename
     Announce "here"
     Announce $file.FullName
-    $ff = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
+    $ff = Get-Content -Encoding Byte -Path $file.FullName
     Announce $ff
     [byte[]]$bytes = Get-Content -Encoding Byte -ReadCount 3 -TotalCount 3 -Path $file.FullName
     Announce "here2"


### PR DESCRIPTION
- include `start` command on server-side component to manually start a SLURM job
- added support to customize SLURM job hosting VS Code sessions